### PR TITLE
elimino la opcion live the bets

### DIFF
--- a/src/app/bets/page.tsx
+++ b/src/app/bets/page.tsx
@@ -14,7 +14,7 @@ const bets: IBetv2[] = [
     stake: 100,
     odds: 2.5,
     potential: 250,
-    kind: MenuState.LIVE,
+    kind: MenuState.OPEN,
   },
   {
     title: "EuroCup Qualifiers",
@@ -56,7 +56,7 @@ const bets: IBetv2[] = [
     stake: 200,
     odds: 2.1,
     potential: 420,
-    kind: MenuState.LIVE,
+    kind: MenuState.OPEN,
   },
   {
     title: "ATP Wimbledon Final",
@@ -114,15 +114,19 @@ const bets: IBetv2[] = [
 ];
 
 export default function Page() {
-  const [state, setState] = useState(MenuState.LIVE);
+  const [state, setState] = useState(MenuState.OPEN);
 
   return (
     <div className="mb-16">
       <Menu state={state} setState={setState} />
-      <div className="flex flex-col items-center gap-5 m-5">
-        {bets
-          .filter((bet) => bet.kind === state)
-          .map((bet, index) => <Betv2 key={`bet-page-${index}`} {...bet} />)}
+      <div className="bg-gray-900 text-white mx-6">
+        <div className="max-w-md mx-auto">
+          <div className="flex flex-col items-center gap-5 py-5">
+            {bets
+              .filter((bet) => bet.kind === state)
+              .map((bet, index) => <Betv2 key={`bet-page-${index}`} {...bet} />)}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/bets/Betv2.tsx
+++ b/src/components/bets/Betv2.tsx
@@ -20,7 +20,7 @@ export type IBetv2 =
   & BetBasev2
   & (
     | {
-      kind: MenuState.LIVE | MenuState.OPEN;
+      kind: MenuState.OPEN;
     }
     | {
       kind: MenuState.SETTLED;

--- a/src/components/bets/Menu.tsx
+++ b/src/components/bets/Menu.tsx
@@ -1,29 +1,6 @@
 export enum MenuState {
-  LIVE,
   OPEN,
   SETTLED,
-}
-
-interface IKind {
-  state: MenuState;
-  setState: (state: MenuState) => void;
-  kind: MenuState;
-  children?: React.ReactNode;
-}
-
-function Kind({ state, setState, kind, children }: IKind) {
-  return (
-    <div
-      onClick={() => setState(kind)}
-      className={`px-2 py-1 transition-colors duration-300 ease-in-out rounded-md text-xs ${
-        state === kind
-          ? "text-white bg-gray-800"
-          : "text-neutral-400 hover:text-white"
-      }`}
-    >
-      {children}
-    </div>
-  );
 }
 
 interface IMenu {
@@ -33,16 +10,29 @@ interface IMenu {
 
 export default function Menu({ state, setState }: IMenu) {
   return (
-    <div className="w-full flex flex-row justify-evenly pt-2">
-      <Kind state={state} setState={setState} kind={MenuState.LIVE}>
-        <p className="text-sm">Live</p>
-      </Kind>
-      <Kind state={state} setState={setState} kind={MenuState.OPEN}>
-        <p className="text-sm">Open</p>
-      </Kind>
-      <Kind state={state} setState={setState} kind={MenuState.SETTLED}>
-        <p className="text-sm">Settled</p>
-      </Kind>
+    <div className="bg-gray-900 text-white mx-6 mt-2">
+      <div className="max-w-md mx-auto">
+        <div className="flex justify-between mb-4 gap-2">
+          {Object.keys(MenuState)
+            .filter(key => isNaN(Number(key)))
+            .map(tab => {
+              const tabState = MenuState[tab as keyof typeof MenuState];
+              return (
+                <button
+                  key={tab}
+                  className={`flex-1 py-2 transition-colors duration-300 ease-in-out rounded-md text-xs ${
+                    state === tabState
+                      ? "text-white bg-gray-800"
+                      : "text-neutral-400 hover:text-white"
+                  }`}
+                  onClick={() => setState(tabState)}
+                >
+                  {tab.charAt(0).toUpperCase() + tab.slice(1).toLowerCase()}
+                </button>
+              );
+            })}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
# Rediseño de la sección de apuestas

Este PR elimina la opción "LIVE" del menú de apuestas y rediseña la interfaz para que coincida con el estilo de la sección de perfil.

## Cambios principales:
- Se eliminó la opción "LIVE" del enum MenuState
- Se actualizó el diseño del componente Menu para que coincida con el estilo de las pestañas del perfil


Estos cambios mejoran la consistencia visual de la aplicación y simplifican la navegación para los usuarios.