### PR TITLE
Alineando el titulo y numero en el pnl del history

### DIFF
--- a/src/components/profile/History.tsx
+++ b/src/components/profile/History.tsx
@@ -237,8 +237,8 @@ export default function History() {
 
   return (
     <div className="mb-6">
-      <div className="flex justify-between items-center">
-        <h3 className="text-lg mb-4">PnL Graph</h3>
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg">PnL Graph</h3>
         <h3 className={`text-lg ${totalBalance >= 0 ? "text-[#23C45E]" : "text-[#EF4444]"}`}>
           {totalBalance} $
         </h3>


### PR DESCRIPTION
Actualmente:
![Screenshot 2025-05-27 at 2 27 44 PM](https://github.com/user-attachments/assets/3205166f-d06d-4617-912c-041c0bed3052)

Con este cambio:
![Screenshot 2025-05-27 at 2 26 44 PM](https://github.com/user-attachments/assets/fd5e8f34-4049-4789-ab03-096cb10764c3)
