### PR TITLE
Fix contract variable name

### DIFF
--- a/src/hooks/useGetBalance.ts
+++ b/src/hooks/useGetBalance.ts
@@ -7,7 +7,7 @@ import { stableTokenABI } from "@celo/abis";
 import { tokenMap } from "@/hooks/useTransaction";
 
 async function check(address: `0x${string}`) {
-  const constract = getContract({
+  const contract = getContract({
     abi: stableTokenABI,
     address: tokenMap["cUSD"].address,
     publicClient: createPublicClient({
@@ -16,7 +16,7 @@ async function check(address: `0x${string}`) {
     }),
   });
 
-  const balance = await constract.read.balanceOf([
+  const balance = await contract.read.balanceOf([
     address,
   ]);
 


### PR DESCRIPTION
## Summary
- rename `constract` to `contract` in the balance hook

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684604fc07bc8332b3ed750c7957af85