### PR TITLE
Fix bet list keys

### DIFF
--- a/src/app/bets/page.tsx
+++ b/src/app/bets/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Betv2, { type IBetv2 } from "@/components/bets/Betv2";
+import Betv2, { type IBetv2, hashBet } from "@/components/bets/Betv2";
 import Menu, { MenuState } from "@/components/bets/Menu";
 import { getPastEvents } from "@/utils/data/dataService";
 
@@ -166,10 +166,20 @@ export default function Page() {
             {state === MenuState.OPEN ? (
               bets
                 .filter((bet) => bet.kind === state)
-                .map((bet, index) => <Betv2 key={`bet-page-${index}`} {...bet} />)
+                .map((bet) => (
+                  <Betv2
+                    key={bet.eventId || hashBet({ date: bet.date, title: bet.title })}
+                    {...bet}
+                  />
+                ))
             ) : (
               settledBets.length > 0 ? (
-                settledBets.map((bet: IBetv2, index: number) => <Betv2 key={`settled-bet-${index}`} {...bet} />)
+                settledBets.map((bet: IBetv2) => (
+                  <Betv2
+                    key={bet.eventId || hashBet({ date: bet.date, title: bet.title })}
+                    {...bet}
+                  />
+                ))
               ) : (
                 <div className="text-neutral-400 text-center p-4">
                   <p>No settled bets found</p>

--- a/src/components/BetSlip.tsx
+++ b/src/components/BetSlip.tsx
@@ -139,8 +139,8 @@ export default function Betslip() {
                   </button>
                 </div>
                 <div>
-                  {bets.map((bet, index) => (
-                    <Bet {...bet} key={`betslip-${index}`} />
+                  {bets.map((bet) => (
+                    <Bet {...bet} key={bet.id} />
                   ))}
                 </div>
                 <div className="flex flex-col gap-3">

--- a/src/components/profile/History.tsx
+++ b/src/components/profile/History.tsx
@@ -248,8 +248,11 @@ export default function History() {
       <BalanceOverview history={history} />
       <h3 className="text-lg mb-4">Detailed Overview</h3>
       <div className="space-y-4">
-        {betData.map((bet, index) => (
-          <BetDetails key={index} {...bet} />
+        {betData.map((bet) => (
+          <BetDetails
+            key={hashBet({ date: bet.date, title: bet.title })}
+            {...bet}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- avoid using the array index as key in BetSlip
- generate stable keys for bet history items
- use event id or hashed id as key for bets page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460511e1bc83329b342de89ca17927