### PR TITLE
Iconos de subcategorias y refactorizacion del uso de categorias

### DIFF
--- a/src/app/[section]/page.tsx
+++ b/src/app/[section]/page.tsx
@@ -1,6 +1,5 @@
-import { notFound } from "next/navigation";
 import SectionContent, { SectionData } from "@/components/SectionContent";
-import sections from "@/utils/data/sections";
+import sections, { getSubcategoryIcon } from "@/utils/data/sections";
 import { getEventsBySection } from "@/utils/data/dataService";
 import { Event as EventType } from "@/utils/data/types";
 
@@ -12,81 +11,12 @@ interface SectionPageProps {
 }
 
 export default async function SectionPage({ params }: SectionPageProps) {
-  const section = params.section.toLowerCase();
-  
-  // Find the section metadata from our sections list
-  const sectionMeta = sections.find(s => s.name.toLowerCase() === section || s.id === section);
-  if (!sectionMeta) {
-    console.log(`Page: Section metadata not found for: ${section}`);
-    return notFound();
-  }
-
-  // Get the section ID from the metadata
-  const sectionId = sectionMeta.id;
-  
-  try {
-    // Get events for this section using our enhanced data service
-    const sectionEvents = getEventsBySection(sectionId);
-
-    // Split events into separate arrays by subcategory
-    const subCategories = sectionEvents.reduce((acc, event) => {
-      // Use a default subcategory name if subcategory is undefined
-      const subCat = event.subcategory || 'General';
-      
-      if (acc[subCat]) {
-        acc[subCat].push(event);
-      } else {
-        acc[subCat] = [event];
-      }
-      return acc;
-    }, {} as Record<string, EventType[]>);
-
-    // Transform events into the format expected by SectionContent
+ is
+    
+    // Create the section data with categories
     const sectionData: SectionData = {
-      categories: Object.keys(subCategories).map(subCat => {
-        const subCatEvents = subCategories[subCat];
-        return {
-          title: subCat,
-          items: {
-            // For events with options (multi-choice markets)
-            multiChoice: subCatEvents
-              .filter(event => event.options && event.options.length > 0)
-              .map(event => ({
-                type: "number",
-                id: event.id,
-                title: event.title,
-                totalVolume: event.totalVolume || "N/A",
-                imageUrl: event.imageUrl,
-                options: event.options?.map(opt => ({
-                  name: opt.title,
-                  probability: opt.probability
-                })) || []
-              })),
-            
-            // For binary events (yes/no markets)
-            trends: subCatEvents
-              .filter(event => !event.options && event.historyData && event.historyData.length > 0)
-              .map(event => {
-                // Calculate probability change
-                const historyData = event.historyData || [];
-                const latestProb = event.probability;
-                const earliestProb = historyData.length > 0 ? historyData[0].probability : latestProb;
-                const change = latestProb - earliestProb;
-                const probChange = change >= 0 ? `+${change.toFixed(1)}` : `${change.toFixed(1)}`;
-                
-                return {
-                  type: "trend",
-                  id: event.id,
-                  title: event.title,
-                  probability: event.probability,
-                  probabilityChange: probChange,
-                  image: event.imageUrl,
-                  history: event.historyData || []
-                };
-              })
-          }
-        };
-      })
+      categories: categories as any[],
+      showSeeMore: false
     };
     
     return (
@@ -98,6 +28,52 @@ export default async function SectionPage({ params }: SectionPageProps) {
     console.error(`Page: Error loading data for section: ${section}`, error);
     return notFound();
   }
+}
+
+/**
+ * Format events for display in the UI
+ * @param events Array of events to format
+ * @returns Formatted items object for SectionContent
+ */
+function formatEventsForDisplay(events: EventType[]) {
+  return {
+    // For events with options (multi-choice markets)
+    multiChoice: events
+      .filter(event => event.options && event.options.length > 0)
+      .map(event => ({
+        type: "number",
+        id: event.id,
+        title: event.title,
+        totalVolume: event.totalVolume || "N/A",
+        imageUrl: event.imageUrl,
+        options: event.options?.map(opt => ({
+          name: opt.title,
+          probability: opt.probability
+        })) || []
+      })),
+    
+    // For binary events (yes/no markets)
+    trends: events
+      .filter(event => !event.options && event.historyData && event.historyData.length > 0)
+      .map(event => {
+        // Calculate probability change
+        const historyData = event.historyData || [];
+        const latestProb = event.probability;
+        const earliestProb = historyData.length > 0 ? historyData[0].probability : latestProb;
+        const change = latestProb - earliestProb;
+        const probChange = change >= 0 ? `+${change.toFixed(1)}` : `${change.toFixed(1)}`;
+        
+        return {
+          type: "trend",
+          id: event.id,
+          title: event.title,
+          probability: event.probability,
+          probabilityChange: probChange,
+          image: event.imageUrl,
+          history: event.historyData || []
+        };
+      })
+  };
 }
 
 // Generate static paths for all sections

--- a/src/app/[section]/page.tsx
+++ b/src/app/[section]/page.tsx
@@ -1,33 +1,13 @@
+import { notFound } from "next/navigation";
 import SectionContent, { SectionData } from "@/components/SectionContent";
-import sections, { getSubcategoryIcon } from "@/utils/data/sections";
+import sections, { getCategoryIcon } from "@/utils/data/sections";
 import { getEventsBySection } from "@/utils/data/dataService";
-import { Event as EventType } from "@/utils/data/types";
+import { Event as EventType, SubcategoryInfo } from "@/utils/data/types";
 
-// Define the props for the page component
 interface SectionPageProps {
   params: {
     section: string;
   };
-}
-
-export default async function SectionPage({ params }: SectionPageProps) {
- is
-    
-    // Create the section data with categories
-    const sectionData: SectionData = {
-      categories: categories as any[],
-      showSeeMore: false
-    };
-    
-    return (
-      <div>
-        <SectionContent data={sectionData} />
-      </div>
-    );
-  } catch (error) {
-    console.error(`Page: Error loading data for section: ${section}`, error);
-    return notFound();
-  }
 }
 
 /**
@@ -37,9 +17,8 @@ export default async function SectionPage({ params }: SectionPageProps) {
  */
 function formatEventsForDisplay(events: EventType[]) {
   return {
-    // For events with options (multi-choice markets)
     multiChoice: events
-      .filter(event => event.options && event.options.length > 0)
+      .filter(event => (event.options?.length ?? 0) > 0)
       .map(event => ({
         type: "number",
         id: event.id,
@@ -52,14 +31,12 @@ function formatEventsForDisplay(events: EventType[]) {
         })) || []
       })),
     
-    // For binary events (yes/no markets)
     trends: events
-      .filter(event => !event.options && event.historyData && event.historyData.length > 0)
+      .filter(event => !event.options && (event.historyData?.length ?? 0) > 0)
       .map(event => {
-        // Calculate probability change
         const historyData = event.historyData || [];
         const latestProb = event.probability;
-        const earliestProb = historyData.length > 0 ? historyData[0].probability : latestProb;
+        const earliestProb = historyData[0]?.probability ?? latestProb;
         const change = latestProb - earliestProb;
         const probChange = change >= 0 ? `+${change.toFixed(1)}` : `${change.toFixed(1)}`;
         
@@ -70,10 +47,111 @@ function formatEventsForDisplay(events: EventType[]) {
           probability: event.probability,
           probabilityChange: probChange,
           image: event.imageUrl,
-          history: event.historyData || []
+          history: historyData
         };
       })
   };
+}
+
+/**
+ * Group events by subcategory and format them for display
+ */
+function prepareCategories(sectionId: string, sectionEvents: EventType[], sectionMeta: any) {
+  // If the section has defined subcategories, use them
+  if (sectionMeta.subcategories?.length > 0) {
+    const eventsBySubcategory = new Map<string, EventType[]>();
+    
+    // Initialize map with empty arrays for all subcategories and a general category
+    sectionMeta.subcategories.forEach((sub: SubcategoryInfo) => eventsBySubcategory.set(sub.id, []));
+    eventsBySubcategory.set('general', []);
+    
+    // Distribute events to their respective subcategories
+    sectionEvents.forEach(event => {
+      const subcategoryId = event.subcategory ? 
+        sectionMeta.subcategories?.find((sub: SubcategoryInfo) => 
+          sub.name.toLowerCase() === event.subcategory?.toLowerCase() || 
+          sub.id.toLowerCase() === event.subcategory?.toLowerCase()
+        )?.id : null;
+      
+      if (subcategoryId && eventsBySubcategory.has(subcategoryId)) {
+        eventsBySubcategory.get(subcategoryId)?.push(event);
+      } else {
+        eventsBySubcategory.get('general')?.push(event);
+      }
+    });
+    
+    // Convert subcategories to the format expected by SectionContent
+    const categories = sectionMeta.subcategories
+      .map((subcategory: SubcategoryInfo) => {
+        const subCatEvents = eventsBySubcategory.get(subcategory.id) || [];
+        if (subCatEvents.length === 0) return null;
+        
+        return {
+          id: subcategory.id,
+          title: subcategory.name,
+          icon: getCategoryIcon(subcategory.id, 'inline-block text-bb-accent', 16),
+          items: formatEventsForDisplay(subCatEvents)
+        };
+      })
+      .filter(Boolean);
+    
+    // Add general category if it has events
+    const generalEvents = eventsBySubcategory.get('general') || [];
+    if (generalEvents.length > 0) {
+      categories.push({
+        id: 'general',
+        title: 'General',
+        icon: getCategoryIcon(sectionId, 'inline-block text-bb-accent', 16),
+        items: formatEventsForDisplay(generalEvents)
+      });
+    }
+    
+    return categories;
+  } 
+  
+  // If no subcategories defined, group by event subcategory
+  const subCategories = sectionEvents.reduce((acc, event) => {
+    const subCat = event.subcategory || 'General';
+    if (!acc[subCat]) acc[subCat] = [];
+    acc[subCat].push(event);
+    return acc;
+  }, {} as Record<string, EventType[]>);
+
+  // Transform events into the format expected by SectionContent
+  return Object.keys(subCategories).map(subCat => {
+    const subCatEvents = subCategories[subCat];
+    return {
+      id: subCat.toLowerCase().replace(/\s+/g, '-'),
+      title: subCat,
+      icon: getCategoryIcon(subCat, 'inline-block text-bb-accent', 16),
+      items: formatEventsForDisplay(subCatEvents)
+    };
+  });
+}
+
+export default async function SectionPage({ params }: SectionPageProps) {
+  const section = params.section.toLowerCase();
+  
+  // Find the section metadata from our sections list
+  const sectionMeta = sections.find(s => s.name.toLowerCase() === section || s.id === section);
+  if (!sectionMeta) return notFound();
+
+  try {
+    // Get events and prepare categories
+    const sectionEvents = getEventsBySection(sectionMeta.id);
+    const categories = prepareCategories(sectionMeta.id, sectionEvents, sectionMeta);
+    
+    // Create the section data
+    const sectionData: SectionData = {
+      categories,
+      showSeeMore: false
+    };
+    
+    return <SectionContent data={sectionData} />;
+  } catch (error) {
+    console.error(`Error loading data for section: ${section}`, error);
+    return notFound();
+  }
 }
 
 // Generate static paths for all sections

--- a/src/app/api/home/route.ts
+++ b/src/app/api/home/route.ts
@@ -34,6 +34,7 @@ export function GET(_request: NextRequest) {
             const sectionEvents = eventsBySection[section.id] || [];
             return {
                 title: section.name,
+                // icon is optional, so we can omit it in server components
                 items: {
                     // For events with options (multi-choice markets)
                     multiChoice: sectionEvents

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import Footer from "@/components/Footer";
 import Partners from "@/components/Partners";
-import { FaLandmark, FaFootball, FaPiggyBank, FaAnglesRight } from "react-icons/fa6";
+import { FaAnglesRight } from "react-icons/fa6";
 // Import data service and types
 import { getHomeData } from "@/utils/data/dataService";
 import { CategoryData } from "@/utils/data/types";
 import Link from "next/link";
-import sections from "@/utils/data/sections";
+import sections, { getCategoryIcon } from "@/utils/data/sections";
 import { ItemsRenderer } from "@/components/ItemsRenderer";
 
 
@@ -44,24 +44,7 @@ const CompItem = ({ icon, title, items }: PageProps) => {
     );
 };
 
-const getCategoryIcon = (title: string) => {
-    switch (title.toLowerCase()) {
-        case 'sports':
-            return <FaFootball className="text-bb-accent inline-block" />;
-        case 'economy':
-            return <FaPiggyBank className="text-bb-accent inline-block" />;
-        case 'politics':
-            return <FaLandmark className="text-bb-accent inline-block" />;
-        default:
-            return <FaLandmark className="text-bb-accent inline-block" />;
-    }
-};
-
-
-
-// Page is now an async component
 export default async function Page() {
-    // Get data from the data service
     const data = getHomeData();
     
     return (
@@ -69,7 +52,7 @@ export default async function Page() {
             {data.categories.map((category, index) => (
                 <CompItem
                     key={index}
-                    icon={getCategoryIcon(category.title)}
+                    icon={getCategoryIcon(category.title, 'inline-block text-bb-accent', 12)}
                     title={category.title}
                     items={category.items}
                 />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,7 @@ export default async function Page() {
             {data.categories.map((category, index) => (
                 <CompItem
                     key={index}
-                    icon={getCategoryIcon(category.title, 'inline-block text-bb-accent', 12)}
+                    icon={getCategoryIcon(category.title, 'inline-block text-bb-accent', 16)}
                     title={category.title}
                     items={category.items}
                 />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,17 +8,15 @@ import { useAppContext } from "@/components/Context";
 import { useEffect } from "react";
 import useGetAddress from "@/hooks/useGetAddress";
 import useGetBalance from "@/hooks/useGetBalance";
-import sections from "@/utils/data/sections";
+import sections, { getCategoryIcon } from "@/utils/data/sections";
 
 const Icon = ({
   name,
-  icon,
 }: {
   name: string;
-  icon: React.ReactElement;
 }) => (
   <div className="flex items-center justify-center gap-1 flex-col min-w-10 max-w-10 text-neutral-400 hover:text-white transition-colors duration-300">
-    {React.cloneElement(icon, { size: 24 })}
+    {getCategoryIcon(name, '', 24)}
     <span className="text-xs">{name}</span>
   </div>
 );
@@ -84,7 +82,7 @@ export default function Header() {
             href={section.path}
             className="mr-5"
           >
-            <Icon name={section.name} icon={section.icon} />
+            <Icon name={section.name} />
           </Link>
         ))}
       </div>

--- a/src/components/SectionContent.tsx
+++ b/src/components/SectionContent.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { FaLandmark, FaFootball, FaPiggyBank } from "react-icons/fa6";
+// No need for direct icon imports as we're using the centralized getCategoryIcon
 import Partners from "@/components/Partners";
 import Footer from "@/components/Footer";
 import { ItemsRenderer } from "@/components/ItemsRenderer";
 import { CategoryData } from "@/utils/data/types";
+import { getCategoryIcon } from "@/utils/data/sections";
 
 export interface SectionData {
     categories: CategoryData[];
@@ -38,18 +39,7 @@ const CompItem = ({ icon, title, items }: CompItemProps) => {
     );
 };
 
-export const getCategoryIcon = (title: string) => {
-    switch (title.toLowerCase()) {
-        case 'sports':
-            return <FaFootball className="text-bb-accent inline-block" />;
-        case 'economy':
-            return <FaPiggyBank className="text-bb-accent inline-block" />;
-        case 'politics':
-            return <FaLandmark className="text-bb-accent inline-block" />;
-        default:
-            return <FaLandmark className="text-bb-accent inline-block" />;
-    }
-};
+// Using centralized getCategoryIcon from sections.tsx
 
 export default function SectionContent({ data }: { data: SectionData }) {
     return (
@@ -67,7 +57,7 @@ export default function SectionContent({ data }: { data: SectionData }) {
             {data.categories.map((category, index) => (
                 <CompItem
                     key={index}
-                    icon={getCategoryIcon(category.title)}
+                    icon={getCategoryIcon(category.title, 'inline-block text-bb-accent', 20)}
                     title={category.title}
                     items={category.items}
                 />

--- a/src/components/SectionContent.tsx
+++ b/src/components/SectionContent.tsx
@@ -15,7 +15,7 @@ const HandleWhichComponent = ({ items }: { items: CategoryData['items'] }) => {
 };
 
 interface CompItemProps {
-    icon: JSX.Element;
+    icon?: JSX.Element;
     title: string;
     items: CategoryData['items'];
 }
@@ -25,7 +25,7 @@ const CompItem = ({ icon, title, items }: CompItemProps) => {
         <div className="flex flex-col mx-3 mt-2 gap-3 text-xs">
             <div className="flex flex-row justify-between">
                 <div className="flex flex-row gap-1 items-center">
-                    {icon}
+                    {icon && icon}
                     <h1 className="text-white font-bold font-just text-sm capitalize">
                         {title}
                     </h1>

--- a/src/components/SectionContent.tsx
+++ b/src/components/SectionContent.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-// No need for direct icon imports as we're using the centralized getCategoryIcon
 import Partners from "@/components/Partners";
 import Footer from "@/components/Footer";
 import { ItemsRenderer } from "@/components/ItemsRenderer";
 import { CategoryData } from "@/utils/data/types";
-import { getCategoryIcon } from "@/utils/data/sections";
 
 export interface SectionData {
     categories: CategoryData[];
@@ -57,7 +55,7 @@ export default function SectionContent({ data }: { data: SectionData }) {
             {data.categories.map((category, index) => (
                 <CompItem
                     key={index}
-                    icon={getCategoryIcon(category.title, 'inline-block text-bb-accent', 20)}
+                    icon={category.icon}
                     title={category.title}
                     items={category.items}
                 />

--- a/src/utils/data/sections.tsx
+++ b/src/utils/data/sections.tsx
@@ -1,6 +1,9 @@
-import { FaBolt, FaLandmark, FaFootball, FaBitcoin, FaChartLine, FaGlobe } from "react-icons/fa6";
+import React from "react";
+import { FaBolt, FaLandmark, FaFootballBall, FaBitcoin, FaChartLine, FaGlobe, FaBalanceScale, FaFileContract, FaFutbol, FaBasketballBall, FaTableTennis } from "react-icons/fa";
+import { FaChartSimple, FaHouseChimney, FaPersonWalking, FaArrowTrendUp, FaCoins, FaCartShopping, FaHandshake, FaBuildingColumns, FaFire, FaPeopleGroup, FaMicrochip } from "react-icons/fa6";
 import { IoBriefcaseOutline } from "react-icons/io5";
-import { SectionInfo } from "./types";
+import { SiEthereum } from "react-icons/si";
+import { SectionInfo, SubcategoryInfo } from "./types";
 
 const sections: SectionInfo[] = [
   { 
@@ -14,6 +17,7 @@ const sections: SectionInfo[] = [
       lastUpdated: new Date().toISOString(),
       totalEvents: 0
     }
+    // No subcategories for trending as it's a dynamic collection
   },
   { 
     id: "politics",
@@ -21,6 +25,11 @@ const sections: SectionInfo[] = [
     icon: <FaLandmark className="inline-block" />, 
     path: "/politics",
     description: "Political events and predictions",
+    subcategories: [
+      { id: "judiciary", name: "Judiciary", icon: <FaBalanceScale className="inline-block" /> },
+      { id: "trade", name: "Trade", icon: <FaHandshake className="inline-block" /> },
+      { id: "legislation", name: "Legislation", icon: <FaFileContract className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -30,9 +39,14 @@ const sections: SectionInfo[] = [
   { 
     id: "sports",
     name: "Sports", 
-    icon: <FaFootball className="inline-block" />, 
+    icon: <FaFootballBall className="inline-block" />, 
     path: "/sports",
     description: "Sports events and predictions",
+    subcategories: [
+      { id: "soccer", name: "Soccer", icon: <FaFutbol className="inline-block" /> },
+      { id: "basketball", name: "Basketball", icon: <FaBasketballBall className="inline-block" /> },
+      { id: "tennis", name: "Tennis", icon: <FaTableTennis className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -45,6 +59,12 @@ const sections: SectionInfo[] = [
     icon: <IoBriefcaseOutline className="inline-block" />, 
     path: "/economics",
     description: "Economic events and predictions",
+    subcategories: [
+      { id: "gdp", name: "GDP", icon: <FaChartSimple className="inline-block" /> },
+      { id: "housing", name: "Housing", icon: <FaHouseChimney className="inline-block" /> },
+      { id: "employment", name: "Employment", icon: <FaPersonWalking className="inline-block" /> },
+      { id: "inflation", name: "Inflation", icon: <FaArrowTrendUp className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -57,6 +77,11 @@ const sections: SectionInfo[] = [
     icon: <FaBitcoin className="inline-block" />, 
     path: "/crypto",
     description: "Cryptocurrency events and predictions",
+    subcategories: [
+      { id: "bitcoin", name: "Bitcoin", icon: <FaBitcoin className="inline-block" /> },
+      { id: "ethereum", name: "Ethereum", icon: <SiEthereum className="inline-block" /> },
+      { id: "altcoins", name: "Altcoins", icon: <FaCoins className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -69,6 +94,12 @@ const sections: SectionInfo[] = [
     icon: <FaChartLine className="inline-block" />, 
     path: "/finance",
     description: "Financial markets and investment predictions",
+    subcategories: [
+      { id: "markets", name: "Markets", icon: <FaCartShopping className="inline-block" /> },
+      { id: "companies", name: "Companies & Deals", icon: <FaHandshake className="inline-block" /> },
+      { id: "commodities", name: "Commodities", icon: <FaCoins className="inline-block" /> },
+      { id: "banking", name: "Banking", icon: <FaBuildingColumns className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -81,6 +112,11 @@ const sections: SectionInfo[] = [
     icon: <FaGlobe className="inline-block" />, 
     path: "/world",
     description: "Global events and international predictions",
+    subcategories: [
+      { id: "crises", name: "Crises", icon: <FaFire className="inline-block" /> },
+      { id: "culture", name: "Culture & Society", icon: <FaPeopleGroup className="inline-block" /> },
+      { id: "tech", name: "Tech", icon: <FaMicrochip className="inline-block" /> }
+    ],
     featuredEventIds: [],
     metadata: {
       lastUpdated: new Date().toISOString(),
@@ -89,5 +125,105 @@ const sections: SectionInfo[] = [
   },
   // { name: "Search", icon: <FaMagnifyingGlass className="inline-block" />, path: "/search" },
 ];
+
+/**
+ * Get the icon component for a category or subcategory by its name or ID with custom styling
+ * @param categoryNameOrId The name or ID of the category or subcategory
+ * @param className Optional CSS class to apply to the icon (e.g., 'text-bb-accent')
+ * @param size Optional size to apply to the icon (e.g., 24)
+ * @returns The icon component for the category/subcategory with custom styling or a default icon if not found
+ */
+export const getCategoryIcon = (categoryNameOrId: string, className?: string, size?: number) => {
+  const normalizedInput = categoryNameOrId.toLowerCase();
+  let iconElement = null;
+  
+  // First try to match by section ID
+  const sectionById = sections.find(s => s.id.toLowerCase() === normalizedInput);
+  if (sectionById) iconElement = sectionById.icon;
+  
+  // Then try to match by section name
+  else {
+    const sectionByName = sections.find(s => s.name.toLowerCase() === normalizedInput);
+    if (sectionByName) iconElement = sectionByName.icon;
+    
+    // Try to find a matching subcategory
+    else {
+      for (const section of sections) {
+        if (section.subcategories) {
+          // Check subcategory by ID
+          const subcategoryById = section.subcategories.find(
+            sub => sub.id.toLowerCase() === normalizedInput
+          );
+          if (subcategoryById && subcategoryById.icon) {
+            iconElement = subcategoryById.icon;
+            break;
+          }
+          
+          // Check subcategory by name
+          const subcategoryByName = section.subcategories.find(
+            sub => sub.name.toLowerCase() === normalizedInput
+          );
+          if (subcategoryByName && subcategoryByName.icon) {
+            iconElement = subcategoryByName.icon;
+            break;
+          }
+        }
+      }
+      
+      // Handle special cases for backward compatibility
+      if (!iconElement && normalizedInput === 'economy') {
+        const economicsSection = sections.find(s => s.id === 'economics');
+        iconElement = economicsSection ? economicsSection.icon : sections[0].icon;
+      }
+    }
+  }
+  
+  // Use default icon if nothing was found
+  if (!iconElement) iconElement = sections[0].icon;
+  
+  // Apply custom styling if provided
+  const customClass = className || 'inline-block';
+  
+  // Clone the icon with new props
+  return React.cloneElement(iconElement, { 
+    className: customClass,
+    size: size
+  });
+};
+
+/**
+ * Get a subcategory icon by its ID and parent section ID with custom styling
+ * @param sectionId The ID of the parent section
+ * @param subcategoryId The ID of the subcategory
+ * @param className Optional CSS class to apply to the icon (e.g., 'text-bb-accent')
+ * @param size Optional size to apply to the icon (e.g., 24)
+ * @returns The icon component for the subcategory with custom styling or the section icon if not found
+ */
+export const getSubcategoryIcon = (sectionId: string, subcategoryId: string, className?: string, size?: number) => {
+  const section = sections.find(s => s.id.toLowerCase() === sectionId.toLowerCase());
+  if (!section) return React.cloneElement(sections[0].icon, { 
+    className: className || 'inline-block',
+    size: size
+  });
+  
+  let iconElement = section.icon; // Default to section icon
+  
+  if (section.subcategories) {
+    // Explicitly type the subcategory as SubcategoryInfo
+    const subcategory: SubcategoryInfo | undefined = section.subcategories.find(
+      sub => sub.id.toLowerCase() === subcategoryId.toLowerCase()
+    );
+    if (subcategory && subcategory.icon) iconElement = subcategory.icon;
+  }
+  
+  // Apply custom styling
+  const customClass = className || 'inline-block';
+  
+  // Clone the icon with new props
+  return React.cloneElement(iconElement, { 
+    className: customClass,
+    size: size
+  });
+};
 
 export default sections;

--- a/src/utils/data/types.ts
+++ b/src/utils/data/types.ts
@@ -152,6 +152,14 @@ export interface CategoryData {
   };
 }
 
+// Subcategory type
+export interface SubcategoryInfo {
+  id: string;                    // Unique identifier for the subcategory
+  name: string;                  // Display name
+  icon?: ReactElement;           // Optional icon reference
+  description?: string;          // Optional description
+}
+
 // Section types
 export interface SectionInfo {
   id: string;                    // Unique identifier (live, politics, sports, etc.)
@@ -159,6 +167,7 @@ export interface SectionInfo {
   icon: ReactElement;            // Icon reference
   path: string;                  // URL path
   description?: string;          // Optional description
+  subcategories?: SubcategoryInfo[]; // Subcategories within this section
   featuredEventIds?: string[];   // IDs of events to feature in this section
   filters?: SectionFilter[];     // Available filters for this section
   metadata?: {

--- a/src/utils/data/types.ts
+++ b/src/utils/data/types.ts
@@ -136,7 +136,7 @@ export interface HomeData {
 export interface CategoryData {
   id?: string;
   title: string;
-  icon: JSX.Element;             // Category icon
+  icon?: JSX.Element;            // Category icon (optional for API routes)
   description?: string;          // Category description
   items: {
     trends?: MarketTrendData[];

--- a/src/utils/data/types.ts
+++ b/src/utils/data/types.ts
@@ -136,6 +136,7 @@ export interface HomeData {
 export interface CategoryData {
   id?: string;
   title: string;
+  icon: JSX.Element;             // Category icon
   description?: string;          // Category description
   items: {
     trends?: MarketTrendData[];


### PR DESCRIPTION
Dentro de utils/data/sections.tsx actualmente esta toda la informacion de categorias y subcategorias, con funciones helper para iconos y demas.

Ejemplos de como estuvo quedando: 
![Screenshot 2025-07-01 at 11 12 00 AM](https://github.com/user-attachments/assets/0d2606e8-a019-4f9f-a4c4-6aa915dd2888)
![Screenshot 2025-07-01 at 11 11 44 AM](https://github.com/user-attachments/assets/91984703-7d9d-4359-8431-6385f24b27e4)
![Screenshot 2025-07-01 at 11 11 55 AM](https://github.com/user-attachments/assets/ed79d4a4-3a27-4ac5-8c8c-56221d5c11b7)

